### PR TITLE
Update link for JTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ Backend development is such a broad topic that I'm just going to link to the bri
 - [Geospatial for Java](http://docs.geotools.org/stable/tutorials/) (Java)
 - [Hibernate Spatial](http://www.hibernatespatial.org/documentation/02-Tutorial/01-tutorial4/) (Java)
 - [Proj4J Tutorial](https://trac.osgeo.org/proj4j/) (Java)
-- [JTS Topology Suite](http://www.tsusiatsoftware.net/jts/main.html) (Java)
+- [LocationTech JTS Topology Suite](https://projects.eclipse.org/projects/locationtech.jts) (Java)


### PR DESCRIPTION
The current JTS is maintained by the Eclipse Foundation. The current version 1.19.0 is found using the updated link. 