### PR TITLE
Update Hibernate Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,6 @@ Backend development is such a broad topic that I'm just going to link to the bri
 - [GeoDjango Tutorial](https://docs.djangoproject.com/en/2.1/ref/contrib/gis/tutorial/) (Python)
 - [Make a Location-Based Web App With Django and GeoDjango](https://realpython.com/location-based-app-with-geodjango-tutorial/) (Python)
 - [Geospatial for Java](http://docs.geotools.org/stable/tutorials/) (Java)
-- [Hibernate Spatial](http://www.hibernatespatial.org/documentation/02-Tutorial/01-tutorial4/) (Java)
+- [Hibernate ORM](https://hibernate.org/orm/) (Java)
 - [Proj4J Tutorial](https://trac.osgeo.org/proj4j/) (Java)
 - [JTS Topology Suite](http://www.tsusiatsoftware.net/jts/main.html) (Java)


### PR DESCRIPTION
As of version 3 the Hibernate Spatial is part of the official Hibernate release as noted in the legacy Hibernate Spatial website at http://www.hibernatespatial.org/.

Section 21 of the Hibernate ORM documentation covers the its spatial functionality backed by a choice of JTS or GeoLatte-Geom. For more information see [Section 21. Spatial](https://docs.jboss.org/hibernate/orm/6.4/userguide/html_single/Hibernate_User_Guide.html#spatial)
