### PR TITLE
Fixed link for GeoTools (a.k.a Geospatial for java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Backend development is such a broad topic that I'm just going to link to the bri
 ##### Additional Tutorials
 - [GeoDjango Tutorial](https://docs.djangoproject.com/en/2.1/ref/contrib/gis/tutorial/) (Python)
 - [Make a Location-Based Web App With Django and GeoDjango](https://realpython.com/location-based-app-with-geodjango-tutorial/) (Python)
-- [Geospatial for Java](http://docs.geotools.org/stable/tutorials/) (Java)
+- [GeoTools](https://www.geotools.org/) (Java)
 - [Hibernate Spatial](http://www.hibernatespatial.org/documentation/02-Tutorial/01-tutorial4/) (Java)
 - [Proj4J Tutorial](https://trac.osgeo.org/proj4j/) (Java)
 - [JTS Topology Suite](http://www.tsusiatsoftware.net/jts/main.html) (Java)


### PR DESCRIPTION
I have only known this as GeoTools never Geospatial for Java. The previous link had a 404 response, this pull-request provides the correct link to GeoTools landing page. 